### PR TITLE
Bugfix for PT trip processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 __pycache__
 *.pyc
 /scenario_templates

--- a/s2t_pt.py
+++ b/s2t_pt.py
@@ -115,7 +115,7 @@ def _createValueTuple(od, end, real, sumoTime, sumoDist):
 
 
 @benchmark
-def upload_all_pairs(conn, tables, start, end, real_routes, rep_routes, net, taz_list, startIdx=0):
+def upload_all_pairs(conn, tables, start, end, real_routes, rep_routes, net, startIdx=0):
     stats = list(_parse_person_info_taz(real_routes, start, end))
     print("Parsed taz results for %s persons from %s." % (len(stats), real_routes))
     stats.extend(_get_all_pair_stats(rep_routes, net))

--- a/s2t_pt.py
+++ b/s2t_pt.py
@@ -110,8 +110,8 @@ def _createValueTuple(od, end, real, sumoTime, sumoDist):
     timeMean, timeStd = sumoTime.meanAndStdDev()
     distMean, distStd = sumoDist.meanAndStdDev()
     return base + (sumoTime.count() - real,
-                   "{%s}" % (str(timeMean)[1:-1]), sum(timeStd) / len(timeStd),
-                   "{%s}" % (str(distMean)[1:-1]), sum(distStd) / len(distStd))
+                   "{%s}" % (str(timeMean.tolist())[1:-1]), sum(timeStd) / len(timeStd),
+                   "{%s}" % (str(distMean.tolist())[1:-1]), sum(distStd) / len(distStd))
 
 
 @benchmark
@@ -137,8 +137,8 @@ def upload_all_pairs(conn, tables, start, end, real_routes, rep_routes, net, taz
         if not faked or sumoTime.count() < min_samples:
             if not faked:
                 real += 1
-            sumoTime.add(duration)
-            sumoDist.add(dist)
+            sumoTime.add(np.array(duration))
+            sumoDist.add(np.array(dist))
     if last is not None:
         values.append(_createValueTuple(last, end, real, sumoTime, sumoDist))
     cursor = conn.cursor()


### PR DESCRIPTION
PT trips processing failed on calculation of time and distance statistics (cause provided values were tuples in some cases) and inserting results in database failed cause of wrong format of time and dist mean data.
